### PR TITLE
Saving State by Cookie

### DIFF
--- a/Owin.Security.Providers/Untappd/Provider/UntappdAuthenticatedContext.cs
+++ b/Owin.Security.Providers/Untappd/Provider/UntappdAuthenticatedContext.cs
@@ -28,10 +28,11 @@ namespace Owin.Security.Providers.Untappd
             AccessToken = accessToken;
 
             Id = user["response"]["user"]["id"].ToString();
-            Name = user["response"]["user"]["first_name"].ToString() +" "+ user["response"]["user"]["last_name"].ToString();
+            Name = user["response"]["user"]["first_name"].ToString() + " " + user["response"]["user"]["last_name"].ToString();
             Link = user["response"]["user"]["url"].ToString();
             UserName = user["response"]["user"]["user_name"].ToString();
             Email = user["response"]["user"]["settings"]["email_address"].ToString();
+            AvatarUrl = user["response"]["user"]["user_avatar"].ToString();
         }
 
         /// <summary>
@@ -69,6 +70,11 @@ namespace Owin.Security.Providers.Untappd
         /// Gets the Untappd email
         /// </summary>
         public string Email { get; private set; }
+
+        /// <summary>
+        /// Gets the Untappd avatar url 100x100
+        /// </summary>
+        public string AvatarUrl { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ClaimsIdentity"/> representing the user

--- a/Owin.Security.Providers/Untappd/UntappdAuthenticationMiddleware.cs
+++ b/Owin.Security.Providers/Untappd/UntappdAuthenticationMiddleware.cs
@@ -32,13 +32,21 @@ namespace Owin.Security.Providers.Untappd
             if (Options.Provider == null)
                 Options.Provider = new UntappdAuthenticationProvider();
 
+            if (Options.StateDataFormat == null)
+            {
+                IDataProtector dataProtector = app.CreateDataProtector(
+                    typeof(UntappdAuthenticationMiddleware).FullName,
+                    Options.AuthenticationType, "v1");
+                Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
+            }
+
             if (String.IsNullOrEmpty(Options.SignInAsAuthenticationType))
                 Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
 
             httpClient = new HttpClient(ResolveHttpMessageHandler(Options))
             {
                 Timeout = Options.BackchannelTimeout,
-                MaxResponseContentBufferSize = 1024*1024*10,
+                MaxResponseContentBufferSize = 1024 * 1024 * 10,
             };
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft Owin Untappd middleware");
             httpClient.DefaultRequestHeaders.ExpectContinue = false;


### PR DESCRIPTION
The UntappdAuthenticationHandler.InvokeReplyPathAsync() wasn't able to restore the Properties.RedirectUrl (CallBack) from ApplicationTicket. The Properties must be saved as State and send (by URL or Cookie) to the Authentication Provider. Untapped does not work with "state" via GET, but it worked with Cookie. Without the state, the httphandler gives a 404 on ../signin-Untappd?code=... 